### PR TITLE
Show extra details

### DIFF
--- a/database.markdown
+++ b/database.markdown
@@ -38,6 +38,19 @@ order: 2
           word-break: break-word;
         }
 
+        dt {
+          clear: left;
+          color: darkolivegreen;
+          float: left;
+          font-weight: bold;
+          text-align: right;
+          width: 180px;
+        }
+        dd {
+          margin: 0 0 0 190px;
+          padding: 0 0 0.5em;
+        }
+
     </style>
 </head>
 <body class="mt32">

--- a/database.markdown
+++ b/database.markdown
@@ -88,15 +88,26 @@ order: 2
 
     {% if forloop.first %}
     <tr>
-      {% for pair in row limit: 6 %}
+      {% for pair in row limit:6 %}
         <th>{{ pair[0] }}</th>
       {% endfor %}
     </tr>
     {% endif %}
 
-    {% tablerow pair in row limit: 6 %}
+    {% tablerow pair in row limit:6 %}
       {{ pair[1] | xml_escape }}
     {% endtablerow %}
+
+    <tr class="extra-details" data-author-id="{{ row["AUTHOR_ID"] }}">
+      <td colspan="6">
+        <dl>
+          {% for pair in row offset:6 %}
+            <dt>{{ pair[0] | xml_escape }}:</dt>
+            <dd>{{ pair[1] | xml_escape }}</dd>
+          {% endfor %}
+        </dl>
+      </td>
+    </tr>
 
   {% endfor %}
   </table>

--- a/database.markdown
+++ b/database.markdown
@@ -51,6 +51,14 @@ order: 2
           padding: 0 0 0.5em;
         }
 
+        .extra-details {
+          display: none;
+        }
+
+        tr:not(.extra-details) {
+          cursor: pointer;
+        }
+
     </style>
 </head>
 <body class="mt32">
@@ -95,6 +103,11 @@ order: 2
           }
         </script>
 
+  <script>
+    function showHideExtraDetails(row) {
+      row.nextElementSibling.style.display = (row.nextElementSibling.style.display === "table-row") ? "none" : "table-row";
+    }
+  </script>
 
   <table id="myTable">
   {% for row in site.data.database_final %}
@@ -107,9 +120,11 @@ order: 2
     </tr>
     {% endif %}
 
-    {% tablerow pair in row limit:6 %}
-      {{ pair[1] | xml_escape }}
-    {% endtablerow %}
+    <tr onclick="showHideExtraDetails(this)">
+    {% for pair in row limit:6 %}
+      <td>{{ pair[1] | xml_escape }}</td>
+    {% endfor %}
+    </tr>
 
     <tr class="extra-details" data-author-id="{{ row["AUTHOR_ID"] }}">
       <td colspan="6">


### PR DESCRIPTION
Here's an implementation of the feature you requested whereby a row can be clicked to toggle the display of additional information.  It's a simple implementation and I've left some rough edges for you to polish as you see fit.  There are three commits which you can look at in turn to see the steps I took -- note the comments on each commit for some explanation.